### PR TITLE
fix installation

### DIFF
--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -1,9 +1,6 @@
 VERSION = (1, 0, 0)
 __version__ = '.'.join(map(str, VERSION))
 
-from BeautifulSoup import BeautifulSoup
-import lxml.html
-import lxml.html.clean
 import re
 import unicodedata
 
@@ -51,6 +48,9 @@ def cleanse_html(html,
 
     Requires ``lxml`` and ``beautifulsoup``.
     """
+    from BeautifulSoup import BeautifulSoup
+    import lxml.html
+    import lxml.html.clean
 
     doc = lxml.html.fromstring('<anything>%s</anything>' % html)
     try:

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,5 @@ setup(name='feincms-cleanse',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development',
     ],
+    install_requires=('lxml>=2.2', 'BeautifulSoup>=3'),
 )


### PR DESCRIPTION
don't import 3rd party modules in **init** because **init** is imported in setup.py and required for dependencies resolving
