### PR TITLE
allow empty a-tag (for anchors, which is enabled by default in FeinCMS) ...

### DIFF
--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -16,7 +16,7 @@ class Cleanse(object):
         'h3': (),
         'strong': (),
         'em': (),
-        'p': (),
+        'p': ('class',),
         'ul': (),
         'ol': (),
         'li': (),
@@ -29,7 +29,7 @@ class Cleanse(object):
 
     empty_tags = ('br',)
 
-    empty_content_tags = ('td', 'th', 'p')
+    empty_content_tags = ('td', 'th', 'p', 'a')
 
     merge_tags = ('h2', 'h3', 'strong', 'em', 'ul', 'ol', 'sub', 'sup')
 

--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -9,6 +9,10 @@ import unicodedata
 
 __all__ = ('cleanse_html', 'Cleanse')
 
+
+nonestr = lambda s: '' if s is None else s.strip()
+
+
 class Cleanse(object):
     allowed_tags = {
         'a': ('href', 'name', 'target', 'title'),
@@ -29,7 +33,7 @@ class Cleanse(object):
 
     empty_tags = ('br',)
 
-    empty_content_tags = ('td', 'th', 'p')
+    empty_content_tags = ('td', 'th',)
 
     merge_tags = ('h2', 'h3', 'strong', 'em', 'ul', 'ol', 'sub', 'sup')
 
@@ -101,16 +105,19 @@ class Cleanse(object):
                     continue
 
             # remove empty tags if they are not <br />
-            elif (not element.text and
+            elif (not nonestr(element.text) and
                   element.tag not in (self.empty_tags + self.empty_content_tags)
                   and not len(element)):
+                # drop_tag leaves tag content so if we have <p>&nbsp;</p>
+                # we're left with &nbsp;
+                element.text = ''
                 element.drop_tag()
                 continue
 
             elif element.tag == 'li':
                 # remove p-in-li tags
                 for p in element.findall('p'):
-                    p.text = ' ' + p.text +' '
+                    p.text = ' ' + p.text + ' '
                     p.drop_tag()
 
             # Hook for custom filters:
@@ -140,7 +147,7 @@ class Cleanse(object):
         html = lxml.html.tostring(doc, method='xml')
 
         # remove wrapping tag needed by XML parser
-        html = re.sub(r'</?anything>', '', html)
+        html = re.sub(r'</?anything/?>', '', html)
 
         # remove all sorts of newline characters
         html = html.replace('\n', ' ').replace('\r', ' ')
@@ -185,6 +192,7 @@ class Cleanse(object):
         html = unicodedata.normalize('NFKC', html)
 
         return html
+
 
 # ------------------------------------------------------------------------
 def cleanse_html(html):

--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -44,6 +44,8 @@ class Cleanse(object):
         # TODO: Implement me! This should ensure that the href is either a
         # path without a protocol, or the protocol is known and http/https.
         # Perhaps also add an option to allow/forbid off-site hrefs?
+        if href.startswith('javascript'):
+            return False
         return True
 
 
@@ -132,7 +134,7 @@ class Cleanse(object):
             # Clean hrefs so that they are benign
             href = element.attrib.get('href', None)
             if href is not None and not self.validate_href(href):
-                del element.attrib['href']
+                element.attrib['href'] = ''
 
         # just to be sure, run cleaner again, but this time with even more
         # strict settings

--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -156,6 +156,8 @@ class Cleanse(object):
 
         # merge tags
         for tag in self.merge_tags:
+            # removes tags like </h2><h2>
+            # TODO: are first and last words really necessary
             merge_str = u'\s*</%s>\s*<%s>\s*' % (tag, tag)
             while True:
                 new = re.sub(merge_str, u' ', html)

--- a/feincms_cleanse/tests.py
+++ b/feincms_cleanse/tests.py
@@ -14,6 +14,7 @@ class CleanseTestCase(SimpleTestCase):
     def test_01_cleanse(self):
         class MyCleanse(Cleanse):
             empty_content_tags = ('td', 'th')
+
         entries = [
             (u'<p>&nbsp;</p>', u''),
             (u'<p>           </p>', u''),
@@ -99,5 +100,5 @@ class CleanseTestCase(SimpleTestCase):
 
     def test_09_a_anchor(self):
         entries = (
-            ('<p><a name="test"></a>Text</p>', '<p><a name="test"></a>Text</p>'),
+            ('<p><a name="test"></a>Text</p>', None),
         )

--- a/feincms_cleanse/tests.py
+++ b/feincms_cleanse/tests.py
@@ -1,10 +1,10 @@
-from django.test import TestCase
+from django.test import SimpleTestCase
 from unittest import expectedFailure
 
 from feincms_cleanse import Cleanse
 
 
-class CleanseTestCase(TestCase):
+class CleanseTestCase(SimpleTestCase):
     def run_tests(self, entries, klass=Cleanse):
         for before, after in entries:
             after = before if after is None else after
@@ -12,6 +12,8 @@ class CleanseTestCase(TestCase):
             self.assertEqual(result, after, u"Cleaning '%s', expected '%s' but got '%s'" % (before, after, result))
 
     def test_01_cleanse(self):
+        class MyCleanse(Cleanse):
+            empty_content_tags = ('td', 'th')
         entries = [
             (u'<p>&nbsp;</p>', u''),
             (u'<p>           </p>', u''),
@@ -24,10 +26,11 @@ class CleanseTestCase(TestCase):
             (u'<p>abc<br />def</p>', u'<p>abc<br />def</p>'),
             ]
 
-        self.run_tests(entries)
+        self.run_tests(entries, klass=MyCleanse)
 
     @expectedFailure
     def test_02_a_tag(self):
+
         entries = (
                     ('<a href="/foo">foo</a>', None),
                     ('<a href="/foo" target="some" name="bar" title="baz" cookies="yesplease">foo</a>', '<a href="/foo" target="some" name="bar" title="baz">foo</a>'),
@@ -96,3 +99,8 @@ class CleanseTestCase(TestCase):
                   )
 
         self.run_tests(entries)
+
+    def test_09_a_anchor(self):
+        entries = (
+            ('<p><a name="test"></a>Text</p>', '<p><a name="test"></a>Text</p>'),
+        )

--- a/feincms_cleanse/tests.py
+++ b/feincms_cleanse/tests.py
@@ -1,10 +1,9 @@
-from django.test import TestCase
-from unittest import expectedFailure
+import unittest
 
 from feincms_cleanse import Cleanse
 
 
-class CleanseTestCase(TestCase):
+class CleanseTestCase(unittest.TestCase):
     def run_tests(self, entries, klass=Cleanse):
         for before, after in entries:
             after = before if after is None else after
@@ -26,7 +25,7 @@ class CleanseTestCase(TestCase):
 
         self.run_tests(entries)
 
-    @expectedFailure
+    @unittest.expectedFailure
     def test_02_a_tag(self):
         entries = (
                     ('<a href="/foo">foo</a>', None),
@@ -68,7 +67,7 @@ class CleanseTestCase(TestCase):
 
         self.run_tests(entries)
 
-    @expectedFailure
+    @unittest.expectedFailure
     def test_06_whitelist(self):
         entries = (
                    (u'<script src="http://abc">foo</script>', u''),
@@ -77,7 +76,7 @@ class CleanseTestCase(TestCase):
 
         self.run_tests(entries)
 
-    @expectedFailure
+    @unittest.expectedFailure
     def test_07_configuration(self):
         class MyCleanse(Cleanse):
             allowed_tags = { 'h1': (), 'h2': () }

--- a/feincms_cleanse/tests.py
+++ b/feincms_cleanse/tests.py
@@ -60,6 +60,8 @@ class CleanseTestCase(SimpleTestCase):
         self.run_tests(entries)
 
     def test_05_p_in_p(self):
+        class MyCleanse(Cleanse):
+            empty_content_tags = ('td', 'th')
         entries = (
                    ('<p><p>foo</p></p>', '<p>foo</p>'),
                    (u'<p><p><p>&nbsp;</p> </p><p><br /></p></p>', u' '),
@@ -69,7 +71,7 @@ class CleanseTestCase(SimpleTestCase):
                    ('<p>foo<p>bar</p>baz</p>', '<p>foo</p><p>bar</p>baz'),
                   )
 
-        self.run_tests(entries)
+        self.run_tests(entries, klass=MyCleanse)
 
     def test_06_whitelist(self):
         entries = (


### PR DESCRIPTION
...and p.class, since this is only used if an author adds this specifically to the TinyMCE init script.
