### PR TITLE
Remove automatic span deletion

### DIFF
--- a/feincms_cleanse/__init__.py
+++ b/feincms_cleanse/__init__.py
@@ -99,11 +99,7 @@ class Cleanse(object):
                         element.tag = 'strong'
                     elif 'italic' in style:
                         element.tag = 'em'
-
-                if element.tag == 'span':  # still span
-                    # remove tag, but preserve children and text
-                    element.drop_tag()
-                    continue
+                continue
 
             # remove empty tags if they are not <br />
             elif (not element.text and


### PR DESCRIPTION
Removing span in all cases in a hard coded way is not very practical as there are legitimate use cases. Typically, the underline style (as the use of the `u` tag is very restrictive in HTML5).

On top of this, removing the span tag at this stage is redundant since the same action is performed when the cleaner is re-run (now on line 134).
Therefore, any `span` with:
- a style tag; or
- an unsafe attribute; or
- a tag which is not part of the `allowed_tags` list (currently this list is empty)
will be removed.

On the other hand, removing this part of the code will allow the programmer to allow a tag such as `class` for `span`.